### PR TITLE
replace st.experimental_get_query_params with st.query_params

### DIFF
--- a/streamlit_superapp/__init__.py
+++ b/streamlit_superapp/__init__.py
@@ -6,7 +6,7 @@ except ModuleNotFoundError:
     )
 
 try:
-    st.experimental_get_query_params
+    st.query_params
 except AttributeError:
     raise AttributeError(
         "Streamlit version is too old. Please upgrade it with `pip install streamlit --upgrade`."

--- a/streamlit_superapp/navigation.py
+++ b/streamlit_superapp/navigation.py
@@ -174,7 +174,7 @@ class Navigation:
         page_changed = previous_path != path
 
         if Navigation.use_query_params:
-            st.experimental_set_query_params(path=path)
+            st.query_params['path'] = path
         else:
             path_state = State("navigation:path", default_value=path)
             path_state.initial_value = path
@@ -190,7 +190,7 @@ class Navigation:
     @staticmethod
     def current_path(default: str = PageLoader.root):
         if Navigation.use_query_params:
-            return st.experimental_get_query_params().get("path", [default])[0]
+            return st.query_params.get("path", default)
 
         path_state = State("navigation:path", default_value=default)
 


### PR DESCRIPTION
Fixes #1. As of Streamlit version 1.30 the following have been deprecated and replaced with st.query_params. The PR remedies that and removes the very visible warnings stating this.

st.experimental_get_query_params
st.experimental_set_query_params

I have tested and everything seems to work correctly after these changes.